### PR TITLE
Sort attribute options by value on frontend

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Attribute/OptionSelectBuilder.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Attribute/OptionSelectBuilder.php
@@ -95,8 +95,12 @@ class OptionSelectBuilder implements OptionSelectBuilderInterface
             ['attribute_option' => $this->attributeResource->getTable('eav_attribute_option')],
             'attribute_option.option_id = entity_value.value',
             []
+        )->joinLeft(
+            ['option_value' => $this->attributeResource->getTable('eav_attribute_option_value')],
+            'option_value.option_id = attribute_option.option_id',
+            []
         )->order(
-            'attribute_option.sort_order ASC'
+            ['attribute_option.sort_order ASC', 'option_value.value ASC']
         )->where(
             'super_attribute.product_id = ?',
             $productId


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Sort attribute options by value, when all options have a sort order of 0.

When a product select/swatch attribute contains multiple options, without these options being entered in the admin panel, so via Magento 1 migration or product import or something, all options can have a sort order of 0 in `eav_attribute_option`.
When viewing the product attribute in the admin, a sorting is applied on the value of the options in `eav_attribute_option_value`. You'd expect the same sort order on the frontend as shown there in the admin panel.
Even when such an attribute is saved _without making any changes to the shown order (by value)_, the values of all the options in the `sort_order` column of the `eav_attribute_option` remains `0`.

The change in this PR adds the same default sorting (on value) on the attributes in the frontend. This works as a fallback, `sort_order` is still taken into account first.

### Manual testing scenarios
Create a product attribute with multiple values, which you can use for creating a configurable product.
For instance, a `size` swatch attribute with options 12, 13, 14, and save the attribute. Then add some extra options with a values below and above these options, i.e. 10, 11, 15 and 16.
Now reset the `sort_order` column of all of these options in the `eav_attribute_option` to `0`.
Refreshing the attribute in the admin panel will show nicely sorted options, 10-11-12-13-14-15-16. The `sort_order` of the options will even remain `0` after saving the attribute.
When creating a configurable product and adding simple products with all of these sizes, the swatches won't be sorted as shown in the admin. They will be after applying this patch.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
